### PR TITLE
Removed colon syntax for case/when

### DIFF
--- a/lib/runt.rb
+++ b/lib/runt.rb
@@ -87,10 +87,10 @@ module Runt
       elsif (11..13).include?(number.to_i % 100)
 	"#{number}th"
       else
-	case "#{number.to_i%10}"
-	  when "1": "#{number}st"
-	  when "2": "#{number}nd"
-	  when "3": "#{number}rd"
+	case number.to_i%10
+	  when 1 then "#{number}st"
+	  when 2 then "#{number}nd"
+	  when 3 then "#{number}rd"
 	  else    "#{number}th"
 	end
       end


### PR DESCRIPTION
This is really the right fix for this. The colon syntax for "when"'s is essentially gone due to the new hash syntax in 1.9.
